### PR TITLE
Fix broken From implementations for Point2f and Point2u

### DIFF
--- a/src/point2f.rs
+++ b/src/point2f.rs
@@ -165,7 +165,7 @@ impl From<(f32, f32)> for Point2f {
 impl From<[f32; 2]> for Point2f {
     #[inline]
     fn from(p: [f32; 2]) -> Point2f {
-        Point2f { x: p[0], y: p[0] }
+        Point2f { x: p[0], y: p[1] }
     }
 }
 

--- a/src/point2u.rs
+++ b/src/point2u.rs
@@ -57,7 +57,7 @@ impl From<(u32, u32)> for Point2u {
 impl From<[u32; 2]> for Point2u {
     #[inline]
     fn from(p: [u32; 2]) -> Point2u {
-        Point2u { x: p[0], y: p[0] }
+        Point2u { x: p[0], y: p[1] }
     }
 }
 


### PR DESCRIPTION
They both used the wrong index for `y`. Curiously, `Point2i` does not implement `From<[i32, 2]>`...